### PR TITLE
add linked list support

### DIFF
--- a/linked_list.go
+++ b/linked_list.go
@@ -1,0 +1,160 @@
+package collections
+
+type nodeValue[T Object] struct {
+	value T
+	next  *nodeValue[T]
+}
+
+type LinkedList[T Object] struct {
+	head *nodeValue[T]
+	tail *nodeValue[T]
+	size int
+}
+
+func NewLinkedList[T Object]() *LinkedList[T] {
+	return &LinkedList[T]{
+		head: nil,
+		tail: nil,
+		size: 0,
+	}
+}
+
+func (a *LinkedList[T]) FromArray(items []T) {
+	for _, item := range items {
+		a.Add(item)
+	}
+}
+
+func (a *LinkedList[T]) IsEmpty() bool {
+	return a.Size() == 0
+}
+
+func (a *LinkedList[T]) Size() int {
+	return a.size
+}
+
+func (a *LinkedList[T]) Iterator() Iterator[T] {
+	return NewLinkedListIterator[T](*a)
+}
+
+func (a *LinkedList[T]) ToArray() []T {
+	var (
+		result = make([]T, 0)
+		itr    = a.Iterator()
+	)
+
+	for itr.HasNext() {
+		result = append(result, itr.Next())
+	}
+
+	return result
+}
+
+func (a *LinkedList[T]) Add(item T) {
+	a.size++
+	if a.size == 1 {
+		a.head = &nodeValue[T]{
+			value: item,
+		}
+		a.tail = a.head
+		return
+	}
+	tailNode := a.tail
+	a.tail = &nodeValue[T]{value: item}
+	tailNode.next = a.tail
+}
+
+func (a *LinkedList[T]) Remove(item T) {
+	foundIndex := a.findItem(item)
+	if foundIndex == -1 {
+		return
+	}
+
+	a.Delete(foundIndex)
+}
+
+func (a *LinkedList[T]) Contains(item T) bool {
+	return a.findItem(item) != -1
+}
+
+func (a *LinkedList[T]) Clear() {
+	a.size = 0
+	a.head = nil
+	a.tail = nil
+}
+
+func (a *LinkedList[T]) AddAll(c Collection[T]) {
+	itr := c.Iterator()
+
+	for itr.HasNext() {
+		a.Add(itr.Next())
+	}
+}
+
+func (a *LinkedList[T]) RemoveAll(c Collection[T]) {
+	itr := c.Iterator()
+
+	for itr.HasNext() {
+		a.Remove(itr.Next())
+	}
+}
+
+func (a *LinkedList[T]) Get(index int) (T, error) {
+	var result T
+	if index < 0 || index >= a.size {
+		return result, ErrIndexOutOfBounds
+	}
+
+	var node *nodeValue[T] = a.head
+	for i := 0; i < index; i++ {
+		node = node.next
+	}
+	return node.value, nil
+}
+
+func (a *LinkedList[T]) Set(index int, item T) error {
+	if index < 0 || index >= a.size {
+		return ErrIndexOutOfBounds
+	}
+
+	var node *nodeValue[T] = a.head
+	for i := 0; i < index; i++ {
+		node = node.next
+	}
+
+	node.value = item
+
+	return nil
+}
+
+func (a *LinkedList[T]) Delete(index int) error {
+	if index < 0 || index >= a.size {
+		return ErrIndexOutOfBounds
+	}
+
+	var node *nodeValue[T] = a.head
+	for i := 0; i < index; i++ {
+		node = node.next
+	}
+	node.next = node.next.next
+	a.size--
+
+	return nil
+}
+
+func (a *LinkedList[T]) findItem(item T) int {
+	var (
+		index = 0
+		itr   = a.Iterator()
+	)
+
+	for itr.HasNext() {
+		if itr.Next() == item {
+			return index
+		}
+
+		index++
+	}
+
+	return -1
+}

--- a/linked_list_iterator.go
+++ b/linked_list_iterator.go
@@ -1,0 +1,32 @@
+package collections
+
+type LinkedListIterator[T Object] struct {
+	list         List[T]
+	currentIndex int
+}
+
+func NewLinkedListIterator[T Object](linkedList LinkedList[T]) *LinkedListIterator[T] {
+	return &LinkedListIterator[T]{
+		list:         &linkedList,
+		currentIndex: 0,
+	}
+}
+
+func (itr *LinkedListIterator[T]) HasNext() bool {
+	return itr.currentIndex < itr.list.Size()
+}
+
+func (itr *LinkedListIterator[T]) Next() T {
+	if itr.currentIndex >= itr.list.Size() || itr.currentIndex < 0 {
+		panic(ErrIndexOutOfBounds)
+	}
+
+	item, err := itr.list.Get(itr.currentIndex)
+	if err != nil {
+		panic(err)
+	}
+
+	itr.currentIndex++
+
+	return item
+}

--- a/linked_list_iterator_test.go
+++ b/linked_list_iterator_test.go
@@ -1,0 +1,48 @@
+package collections
+
+import "testing"
+
+func TestLinkedListIterator_Next(t *testing.T) {
+	l := NewLinkedList[int]()
+	l.Add(1)
+	l.Add(2)
+
+	itr := NewLinkedListIterator[int](*l)
+
+	if itr.Next() != 1 {
+		t.Errorf("iterator next element must be 1")
+		t.FailNow()
+	}
+
+	if itr.Next() != 2 {
+		t.Errorf("iterator next element must be 2")
+		t.FailNow()
+	}
+}
+
+func TestLinkedListIterator_HasNext(t *testing.T) {
+	l := NewLinkedList[int]()
+	l.Add(1)
+	l.Add(2)
+
+	itr := NewLinkedListIterator[int](*l)
+
+	if itr.HasNext() != true {
+		t.Errorf("iterator must have next element")
+		t.FailNow()
+	}
+
+	itr.Next()
+
+	if itr.HasNext() != true {
+		t.Errorf("iterator must have next element")
+		t.FailNow()
+	}
+
+	itr.Next()
+
+	if itr.HasNext() != false {
+		t.Errorf("iterator must not have next element")
+		t.FailNow()
+	}
+}

--- a/linked_list_test.go
+++ b/linked_list_test.go
@@ -1,0 +1,82 @@
+package collections
+
+import "testing"
+
+func TestLinkedList_Contains(t *testing.T) {
+	l := NewLinkedList[int]()
+	l.Add(1)
+	l.Add(2)
+
+	if l.Contains(2) != true {
+		t.Errorf("element not found in list")
+		t.FailNow()
+	}
+
+	if l.Contains(3) != false {
+		t.Errorf("element found in list")
+		t.FailNow()
+	}
+}
+
+func TestLinkedList_Clear(t *testing.T) {
+	l := NewLinkedList[int]()
+	l.Add(1)
+	l.Add(2)
+
+	l.Clear()
+
+	if l.IsEmpty() != true {
+		t.Errorf("list is not empty")
+		t.FailNow()
+	}
+}
+
+func TestLinkedList_AddAll(t *testing.T) {
+	l := NewLinkedList[int]()
+	l.Add(1)
+	l.Add(2)
+
+	l2 := NewLinkedList[int]()
+
+	l2.AddAll(l)
+
+	if l2.IsEmpty() != false {
+		t.Errorf("list is empty")
+		t.FailNow()
+	}
+
+	t.Log(l2)
+}
+
+func TestLinkedList_Add(t *testing.T) {
+	l := NewLinkedList[int]()
+	l.Add(1)
+	l.Add(2)
+
+	if l.IsEmpty() != false {
+		t.Errorf("list is empty")
+		t.FailNow()
+	}
+}
+
+func TestLinkedList_IsEmpty(t *testing.T) {
+	l := NewLinkedList[int]()
+
+	if l.IsEmpty() != true {
+		t.Errorf("list is not empty; list size: %v", l.Size())
+		t.FailNow()
+	}
+}
+
+func TestLinkedList_Size(t *testing.T) {
+	l := NewLinkedList[int]()
+
+	l.Add(1)
+	l.Add(2)
+	l.Add(3)
+
+	if l.Size() != 3 {
+		t.Errorf("list size incorrect; list size: %v", l.Size())
+		t.FailNow()
+	}
+}


### PR DESCRIPTION
Added new structs for LinkedList and LinkedListIterator.

LinkedList struct contains pointers to head and tail nodes of the list, as well as the size of the collection.

Each node contains a pointer to the next node and value of type T.

LinkedListIterator is a simple copy of the ArrayListIterator, without any changes.

The tests for LinkedList and LinkedListIterator are also copied without modification from the ArrayList implementation.